### PR TITLE
Scope automerge to non-major updates and document the preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,39 @@
 # renovate-config
-Shared renovate config
+
+Shared [Renovate](https://docs.renovatebot.com/) preset.
+
+## Usage
+
+Extend it from a repository's Renovate config:
+
+```json
+{
+  "extends": ["github>nemolize/renovate-config"]
+}
+```
+
+## What this preset sets
+
+On top of [`config:recommended`](https://docs.renovatebot.com/presets-config/#configrecommended):
+
+| Option | Value | Why |
+|---|---|---|
+| `automerge` (via `packageRules`) | enabled for `minor`, `patch`, `pin`, `digest` only | Non-major updates automerge once checks pass; **major updates require manual review**. |
+| `minimumReleaseAge` | `3 days` | A freshly published release (potentially broken or compromised) is not automerged until it has been out for 3 days. |
+| `internalChecksFilter` | `strict` | Hold updates that have not yet satisfied `minimumReleaseAge` instead of merging them early. |
+| `prConcurrentLimit` | `5` | Cap concurrent Renovate PRs so consumer repos are not flooded. Raise it per-repo if you have more capacity. |
+| `timezone` | `Asia/Tokyo` | Reference timezone for any scheduling a consumer adds. |
+| `configMigration` | `true` | Renovate opens a PR to migrate deprecated config fields automatically. |
+
+## Assumptions
+
+Automerge only protects you if your CI gates it. Each consumer repo **should enable branch protection with required status checks** — otherwise a non-major update can merge with no CI run. Renovate uses the platform's native auto-merge (`platformAutomerge`, on by default), so the required-check gate is enforced by the platform.
+
+To opt a repo out of automerge, override it locally:
+
+```json
+{
+  "extends": ["github>nemolize/renovate-config"],
+  "packageRules": [{ "matchUpdateTypes": ["minor", "patch", "pin", "digest"], "automerge": false }]
+}
+```

--- a/default.json
+++ b/default.json
@@ -3,6 +3,14 @@
 	"extends": ["config:recommended"],
 	"configMigration": true,
 	"timezone": "Asia/Tokyo",
-	"automerge": true,
-	"prConcurrentLimit": 5
+	"minimumReleaseAge": "3 days",
+	"internalChecksFilter": "strict",
+	"prConcurrentLimit": 5,
+	"packageRules": [
+		{
+			"description": "Automerge non-major updates only; major updates require manual review",
+			"matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+			"automerge": true
+		}
+	]
 }


### PR DESCRIPTION
## Summary

Make the shared preset safe for the repos that extend it, and document its contract.

Previously the top-level `automerge: true` auto-merged **all** updates — including major version bumps — in every consumer repo, with no release-age guard. This narrows automerge to non-major updates and adds supply-chain guards.

## Changes

- **Scope automerge** — only `minor` / `patch` / `pin` / `digest` automerge; **major updates now require manual review** (via `packageRules`).
- **`minimumReleaseAge: 3 days` + `internalChecksFilter: strict`** — a freshly published (potentially broken or compromised) release is not auto-merged immediately.
- **README** — documents the `extends` usage, every default the preset sets over `config:recommended` and why, the branch-protection / required-status-check assumption automerge depends on, and how to opt a repo out.

## Notes

- `timezone: Asia/Tokyo` is kept (currently inert with no schedule) and its role is now documented in the README as the reference TZ for any scheduling a consumer adds.

## Test plan

- [x] `default.json` validated as well-formed JSON
- [x] `renovate-config-validator` passes against the schema (`Config validated successfully`)
- [x] automerge decision logic verified statically per update type — `major` held for review; `minor` / `patch` / `pin` / `digest` automerge; `lockFileMaintenance` not automerged
- [ ] ~~Confirm a consumer repo's next Renovate run automerges a minor/patch but holds a major for review~~ — deferred: requires waiting for a real Renovate run on a consumer repo; covered statically above
