### PR TITLE
ci: validate the preset against the Renovate schema

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,17 @@
+name: Validate Renovate config
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate the shared preset against the Renovate schema
+        run: npx --yes --package renovate renovate-config-validator --strict default.json


### PR DESCRIPTION
## Summary

Add CI that validates `default.json` against the Renovate config schema on every push to `main` and every PR, so a schema break is caught automatically.

This replaces the throwaway logic-replication check from #2 with the **official** `renovate-config-validator` — it tracks Renovate's own implementation, so it does not drift the way a hand-rolled matching test would.

## Changes

- `.github/workflows/validate.yml` — runs `npx renovate-config-validator --strict default.json` on `ubuntu-24.04`.

## Test plan

- [x] `renovate-config-validator --strict default.json` passes locally (`Config validated successfully`)
- [x] CI run on this PR goes green
